### PR TITLE
Update odoo_install.sh

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -149,7 +149,7 @@ sudo su $OE_USER -c "mkdir $OE_HOME/custom"
 sudo su $OE_USER -c "mkdir $OE_HOME/custom/addons"
 
 echo -e "\n---- Setting permissions on home folder ----"
-sudo chown -R $OE_USER:$OE_USER $OE_HOME/*
+sudo chown -R $OE_USER:$OE_USER /$OE_HOME
 
 echo -e "* Create server config file"
 


### PR DESCRIPTION
The chown statement on the OE_USER directory was failing on Ubuntu 22.04 with message:
  chown: cannot access 'odoo/*': No such file or directory

Changed to syntax that should always work.